### PR TITLE
Add Language type

### DIFF
--- a/arches_vue_utils/src/arches_vue_utils/types.ts
+++ b/arches_vue_utils/src/arches_vue_utils/types.ts
@@ -1,0 +1,8 @@
+export interface Language {
+    code: string;
+    default_direction: "ltr" | "rtl";
+    id: number;
+    isdefault: boolean;
+    name: string;
+    scope: string;
+}


### PR DESCRIPTION
Unblocks testing of archesproject/arches-references#38

This used to be in core arches during dev/7.6.x before we yanked it.