### PR TITLE
Don't raise errors for missing labels

### DIFF
--- a/arches_vue_utils/src/arches_vue_utils/utils.spec.ts
+++ b/arches_vue_utils/src/arches_vue_utils/utils.spec.ts
@@ -17,6 +17,11 @@ function asLabel(valuetype_id: string, language_id: string): Label {
 }
 
 const systemLanguageCode = "en-ZA"; // arbitrary
+const emptyLabel = {
+    value: "",
+    language_id: "",
+    valuetype_id: "",
+};
 
 describe("rankLabel() util", () => {
     const rank = (
@@ -59,21 +64,21 @@ describe("rankLabel() util", () => {
 });
 
 describe("getItemLabel() util", () => {
-    it("Errors if no labels", () => {
-        expect(() =>
+    it("Returns empty label if no labels to search", () => {
+        expect(
             getItemLabel(
                 { labels: [] },
                 systemLanguageCode,
                 systemLanguageCode,
             ),
-        ).toThrow();
-        expect(() =>
+        ).toEqual(emptyLabel);
+        expect(
             getItemLabel(
                 { values: [] },
                 systemLanguageCode,
                 systemLanguageCode,
             ),
-        ).toThrow();
+        ).toEqual(emptyLabel);
     });
     it("Falls back to system language", () => {
         expect(

--- a/arches_vue_utils/src/arches_vue_utils/utils.ts
+++ b/arches_vue_utils/src/arches_vue_utils/utils.ts
@@ -54,7 +54,11 @@ export const getItemLabel = (
 ): Label => {
     const labels = (item as WithLabels).labels ?? (item as WithValues).values;
     if (!labels.length) {
-        throw new Error();
+        return {
+            value: "",
+            language_id: "",
+            valuetype_id: "",
+        };
     }
     return labels.sort(
         (a, b) =>


### PR DESCRIPTION
Discovered in archesproject/arches-lingo#135 that if you have incomplete data, like using the resource editor to create an incomplete scheme, the concept tree would break. The backend is hardened against this in lingo, but to harden the frontend, we need to update this util to not throw.